### PR TITLE
Enable Playbooks, remove Subject, minor UI edits

### DIFF
--- a/Instructions/Labs/LAB[MB-210]_M03Lab01_Make_a_Playbook.md
+++ b/Instructions/Labs/LAB[MB-210]_M03Lab01_Make_a_Playbook.md
@@ -37,6 +37,18 @@ In this exercise, you will create two Playbook Templates: one for Opportunities
 with $1,000,000 or more estimated budget, and one for Opportunities with
 estimated budget between $500,000 and $1,000,000.
 
+### Task 0 – Enable Playbooks
+
+In this task you will enable Playbooks.
+
+1.  Go to your **Sales Hub** application.
+
+2.  Click on **Sales** at the bottom of the left menu to navigate the site map. Select **App Settings** from the list.
+
+3.  Locate and click **Playbook Settings** under the **Sales Administration** settings.
+
+4.  Click the toggle swich to **Enable.
+
 ### Task 1 – Create Playbook Categories
 
 In this task you will create Playbook Categories.

--- a/Instructions/Labs/LAB[MB-210]_M03Lab01_Manage_Product_Catalog.md
+++ b/Instructions/Labs/LAB[MB-210]_M03Lab01_Manage_Product_Catalog.md
@@ -43,7 +43,7 @@ In this task, you will create unit groups for the speakers.
 7.  Click **Related** and select **Units**.
 
 8.  You will find that you only have the default unit **Each** now; you will add
-    three more units. Click **+ Add New Unit**.
+    three more units. Click **+ New Unit**.
 
 9.  Enter **Speaker** for **Name**, **1** for **Quantity**, select **Each** for
     **Base Unit**, and click **Save & Create New** by selecting the carrot to the right of the **Save and Close** button.
@@ -52,7 +52,7 @@ In this task, you will create unit groups for the speakers.
     **Base Unit** and click **Save & Create New**.
 
 11. Enter **Set** for **Name**, **2** for **Quantity**, select **Pair** for
-    **Base Unit** and click **Save**.
+    **Base Unit** and click **Save and Close**.
 
 12. You will now have four unit groups in the list.
 
@@ -108,8 +108,7 @@ In this task, you will create products.
 
 5.  Enter **[my prefix] Top D. HiFi** for **Name**, enter **[myprefix]1234** for **Product ID**,
     select **[my prefix] Speakers** for **Unit Group** (you can easily find it by typing in your prefix), select **Speaker** for **Default
-    Unit**, enter **2** for **Decimals Supported**, select **Products** for
-    **Subject** (you will need to expand Query to select it), and click **Save**.
+    Unit**, enter **2** for **Decimals Supported**, and click **Save**.
 
 6.  Select the **Additional Details** tab.
 
@@ -123,7 +122,7 @@ In this task, you will create products.
 
 10. Click **Publish**.
 
-11. Confirm the publishing.
+11. Click **Confirm** to publish.
 
 12. In the left menu, select **Products** in the Collateral group.
 
@@ -145,7 +144,7 @@ In this task, you will create products.
 
 19. Click **Publish**.
 
-20. Confirm the publishing.
+20. Click **Confirm** to publish.
 
 21. Select **Products** from the left menu.
 
@@ -167,7 +166,7 @@ In this task, you will create products.
 
 28. Click **Publish** to publish the product.
 
-29. Confirm the publishing.
+29. Click **Confirm** to publish.
 
 30. From the left menu, select **Products**.
 

--- a/Instructions/Labs/LAB[MB-210]_M03Lab02_Build_Quotes.md
+++ b/Instructions/Labs/LAB[MB-210]_M03Lab02_Build_Quotes.md
@@ -62,10 +62,11 @@ In this task, you will create an Opportunity and add Products Line Items.
 14. Change the **Quantity** to **4** and click out of the field. The Discount will now kick in and the
     Volume Discount field will show the discounted value.
 
+15. Click **Save and Close**.
+
 ### Task 2 – Create Quote
 
 In this task, you will create a Quote from the Opportunity you created in Task
-1.
 
 1.  Go to your **Dynamics 365 Sales Hub** application.
 
@@ -82,9 +83,13 @@ In this task, you will create a Quote from the Opportunity you created in Task
     quantities look as you expected. You can change the quantities and discount
     the price of each line item.
 
-11. Click **Activate Quote**.
+7.  Click **Activate Quote**.
 
-12. Click **Create PDF** located on the command bar and select **Print Quote for Customer**. Click **Download.**
+8.  Click **Export to PDF** located on the command bar and select **Print Quote for Customer**. Click **Download.**
 
-13. Open the generated document and see what the Quote looks like.
+9.  Open the generated document and see what the Quote looks like.
+
+10. Close the PDF.
+
+11. Close the **Export to PDF** window.
 


### PR DESCRIPTION
-	Module 3: Lab: Make a Playbook
o	Added instructions for enabling Playbooks on the tenant

-	Module 3: Lab: Manage Product Catalog
o	Made minor edits to reflect UI updates
o	Removed instruction to set Subject value. Demo data does not have a configured subject tree. I could not get the Subject tree to display in the Site Map. Raised an issue to ask for guidance.
o	Updated language on Confirm Publishing steps

-	Module 3: Lab: Build Quotes
o	Made minor edits to reflect UI updates
o	Corrected step numbering

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-